### PR TITLE
Fixed a Bug in Sign up and added Back Button to Finance Frame

### DIFF
--- a/src/main/java/main/FinanceFrame.java
+++ b/src/main/java/main/FinanceFrame.java
@@ -51,14 +51,14 @@ public class FinanceFrame extends JFrame {
 	 */
 	public FinanceFrame() {
 		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-		setBounds(100, 100, 321, 374);
+		setBounds(100, 100, 362, 374);
 		contentPane = new JPanel();
 		contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
 		setContentPane(contentPane);
 		GridBagLayout gbl_contentPane = new GridBagLayout();
-		gbl_contentPane.columnWidths = new int[]{0, 0, 0, 0, 0, 0};
+		gbl_contentPane.columnWidths = new int[]{0, 0, 0, 0, 0, 0, 0};
 		gbl_contentPane.rowHeights = new int[]{0, 0, 0};
-		gbl_contentPane.columnWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, Double.MIN_VALUE};
+		gbl_contentPane.columnWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.MIN_VALUE};
 		gbl_contentPane.rowWeights = new double[]{0.0, 1.0, Double.MIN_VALUE};
 		contentPane.setLayout(gbl_contentPane);
 		
@@ -118,11 +118,26 @@ public class FinanceFrame extends JFrame {
 		gbc_btnNewButton_1.gridx = 3;
 		gbc_btnNewButton_1.gridy = 0;
 		contentPane.add(btnNewButton_1, gbc_btnNewButton_1);
+		//back button
+		JButton btnNewButton = new JButton("Back");
+		btnNewButton.addActionListener(new ActionListener() {
+			//back button action
+			public void actionPerformed(ActionEvent e) {
+				dispose();
+				MainMenuFrame menu = new MainMenuFrame();
+				menu.setVisible(true);
+			}
+		});
+		GridBagConstraints gbc_btnNewButton = new GridBagConstraints();
+		gbc_btnNewButton.insets = new Insets(0, 0, 5, 5);
+		gbc_btnNewButton.gridx = 4;
+		gbc_btnNewButton.gridy = 0;
+		contentPane.add(btnNewButton, gbc_btnNewButton);
 				
 		JScrollPane scrollPane = new JScrollPane();
 		GridBagConstraints gbc_scrollPane = new GridBagConstraints();
 		gbc_scrollPane.fill = GridBagConstraints.BOTH;
-		gbc_scrollPane.gridwidth = 5;
+		gbc_scrollPane.gridwidth = 6;
 		gbc_scrollPane.gridx = 0;
 		gbc_scrollPane.gridy = 1;
 		contentPane.add(scrollPane, gbc_scrollPane);

--- a/src/main/java/main/SignUpFrame.java
+++ b/src/main/java/main/SignUpFrame.java
@@ -92,9 +92,9 @@ public class SignUpFrame extends JFrame {
 				String uInput = usernameInput.getText();
 				String pInput = passwordInput.getText();
 				String pFInput = firstPassword.getText();
-				
+				System.out.println(uInput != "" && pInput != "");
 				//checking if the passwords entered match
-				if(pFInput.equals(pInput)) {
+				if(pFInput.equals(pInput) && (!uInput.equals("") && !pInput.equals("") && !pFInput.equals(""))) {
 					//stores username and password into database
 					manager.setUsernamePassword(uInput, pInput);
 					//switches back to login


### PR DESCRIPTION
So I fixed a major bug in the sign up frame that allowed a user to enter nothing for the sign up conditions leading them to create an account with empty strings.  This caused our login page to become accessible if the user didn't enter a password or username because an account was created with empty strings.  I fixed this bug and now the sign up page forces you to enter a username and a password and re-enter the password and if one of these conditions is not met the sign-up page prompts the user to do so and blocks an account being added to the login datatable.

I also added a back button to the finance page that allows the user to go back to the main menu.